### PR TITLE
hook: migrate to getfullargspec

### DIFF
--- a/plugins/util/hook.py
+++ b/plugins/util/hook.py
@@ -11,12 +11,12 @@ def _hook_add(func, add, name=""):
         func._filename = func.__code__.co_filename
 
     if not hasattr(func, "_args"):
-        argspec = inspect.getargspec(func)
+        argspec = inspect.getfullargspec(func)
         if name:
             n_args = len(argspec.args)
             if argspec.defaults:
                 n_args -= len(argspec.defaults)
-            if argspec.keywords:
+            if argspec.varkw:
                 n_args -= 1
             if argspec.varargs:
                 n_args -= 1
@@ -29,9 +29,9 @@ def _hook_add(func, add, name=""):
 
         args = []
         if argspec.defaults:
-            end = bool(argspec.keywords) + bool(argspec.varargs)
+            end = bool(argspec.varkw) + bool(argspec.varargs)
             args.extend(argspec.args[-len(argspec.defaults) : end if end else None])
-        if argspec.keywords:
+        if argspec.varkw:
             args.append(0)  # means kwargs present
         func._args = args
 


### PR DESCRIPTION
Migrate to `getfullargspec`, `getargspec` has been removed in Python 3.11